### PR TITLE
Emailjs environmental variables working as intended

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -2,23 +2,19 @@
 import React, { useRef, useState } from "react";
 import emailjs from "@emailjs/browser";
 
-import "dotenv/config";
-
 function Form() {
   const form = useRef<any>();
   const [formSubmit, setFormSubmit] = useState<boolean>(false);
-
-  // console.log(process.env.EMAILPUBLIC_ID);
 
   function sendEmail(event: any) {
     event.preventDefault();
 
     emailjs
       .sendForm(
-        "service_ql4kfzi",
-        "template_cuc1fdf",
+        process.env.NEXT_PUBLIC_EMAILSERVICE_ID,
+        process.env.NEXT_PUBLIC_EMAILTEMPLATE_ID,
         form.current,
-        "8nIg2t_rNO5VjyR2v"
+        process.env.NEXT_PUBLIC_EMAILPUBLIC_ID
       )
       .then((response: any) => {
         console.log("SUCCESS!", response.status, response.text);

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -1,11 +1,10 @@
-
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-    //   [key: string]: string | undefined;
-      EMAILSERVICE_ID: string;
-      EMAILTEMPLATE_ID: string;
-      EMAILPUBLIC_ID: string;
+      //   [key: string]: string | undefined;
+      NEXT_PUBLIC_EMAILSERVICE_ID: string;
+      NEXT_PUBLIC_EMAILTEMPLATE_ID: string;
+      NEXT_PUBLIC_EMAILPUBLIC_ID: string;
       // add more environment variables and their types here
     }
   }


### PR DESCRIPTION
**Task:**
To hide emailjs email service id, template id, and public id.

** Why:**
The application uses these IDs to send users' contact info to the developer. If exposed, can be dangerous and abused by spamming developer's email.

**How:**
In Nextjs, environment variables are placed inside the ".env.local", and variables must be prefixed with "NEXT_PUBLIC_" in order to be read. Variable types can be set and exported from process.env.d.ts. This also gives the intellisense for the key variables.